### PR TITLE
feat: add addToQuery page option to supplement queries

### DIFF
--- a/packages/gatsby-source-prismic-graphql/src/gatsby-node.ts
+++ b/packages/gatsby-source-prismic-graphql/src/gatsby-node.ts
@@ -109,6 +109,7 @@ function createDocumentPages(
   edges.forEach(({ cursor, node }: any, index: number) => {
     const previousNode = edges[index - 1] && edges[index - 1].node;
     const nextNode = edges[index + 1] && edges[index + 1].node;
+    const { _meta, ...restNode } = node;
 
     // ...and create the page
     createPage({
@@ -116,8 +117,8 @@ function createDocumentPages(
       component: page.component,
       context: {
         rootQuery: getRootQuery(page.component),
-        ...node,
-        ...node._meta,
+        ...restNode,
+        ..._meta,
         cursor,
         paginationPreviousMeta: previousNode ? previousNode._meta : null,
         paginationPreviousUid: previousNode ? previousNode._meta.uid : '',
@@ -149,7 +150,6 @@ const getDocumentsQuery = ({
         sortBy: $sortBy
         lang: $lang
       ) {
-        ${querySupplement || ''}
         totalCount
         pageInfo {
           hasNextPage
@@ -158,6 +158,7 @@ const getDocumentsQuery = ({
         edges {
           cursor
           node {
+            ${querySupplement || ''}
             _meta {
               id
               lang
@@ -197,7 +198,7 @@ exports.createPages = async ({ graphql, actions: { createPage } }: any, options:
     const query: string = getDocumentsQuery({
       documentType,
       sortType,
-      querySupplement: page.addToQuery,
+      querySupplement: page.addToNodeQuery,
     });
     const { data, errors } = await graphql(query, {
       after: endCursor,

--- a/packages/gatsby-source-prismic-graphql/src/gatsby-node.ts
+++ b/packages/gatsby-source-prismic-graphql/src/gatsby-node.ts
@@ -134,9 +134,11 @@ function createDocumentPages(
 const getDocumentsQuery = ({
   documentType,
   sortType,
+  querySupplement,
 }: {
   documentType: string;
   sortType: string;
+  querySupplement?: string;
 }): string => `
   query AllPagesQuery ($after: String, $lang: String, $sortBy: ${sortType}) {
     prismic {
@@ -146,6 +148,7 @@ const getDocumentsQuery = ({
         sortBy: $sortBy
         lang: $lang
       ) {
+        ${querySupplement || ''}
         totalCount
         pageInfo {
           hasNextPage
@@ -190,7 +193,11 @@ exports.createPages = async ({ graphql, actions: { createPage } }: any, options:
     // Prepare and execute query
     const documentType: string = `all${page.type}s`;
     const sortType: string = `PRISMIC_Sort${page.type}y`;
-    const query: string = getDocumentsQuery({ documentType, sortType });
+    const query: string = getDocumentsQuery({
+      documentType,
+      sortType,
+      querySupplement: page.addToQuery,
+    });
     const { data, errors } = await graphql(query, {
       after: endCursor,
       lang: lang || null,

--- a/packages/gatsby-source-prismic-graphql/src/gatsby-node.ts
+++ b/packages/gatsby-source-prismic-graphql/src/gatsby-node.ts
@@ -116,6 +116,7 @@ function createDocumentPages(
       component: page.component,
       context: {
         rootQuery: getRootQuery(page.component),
+        ...node,
         ...node._meta,
         cursor,
         paginationPreviousMeta: previousNode ? previousNode._meta : null,

--- a/packages/gatsby-source-prismic-graphql/src/interfaces/PluginOptions.ts
+++ b/packages/gatsby-source-prismic-graphql/src/interfaces/PluginOptions.ts
@@ -6,6 +6,7 @@ export interface Page {
   langs?: string[];
   sortBy?: string;
   filter?: Function;
+  addToQuery?: string;
 }
 
 export interface PluginOptions {

--- a/packages/gatsby-source-prismic-graphql/src/interfaces/PluginOptions.ts
+++ b/packages/gatsby-source-prismic-graphql/src/interfaces/PluginOptions.ts
@@ -6,7 +6,7 @@ export interface Page {
   langs?: string[];
   sortBy?: string;
   filter?: Function;
-  addToQuery?: string;
+  addToNodeQuery?: string;
 }
 
 export interface PluginOptions {


### PR DESCRIPTION
Allow user to inject (from their `gatsby-config` file) additional fields to query on the node using the `addToNodeQuery` Page option. This is useful when:

* the user wishes to filter on non-standard node properties 
* the user has other plugins that rely on data from that first non-page query

In my case, I wanted to add a search capability to my site with `gatsby-plugin-flexsearch`, and wanted to search based on `title` and `body` contents.